### PR TITLE
Fixed deprecation issues and value function bug

### DIFF
--- a/src/js/HexbinLayer.js
+++ b/src/js/HexbinLayer.js
@@ -167,13 +167,13 @@
 				.data(bins, function(d){ return d.i + ':' + d.j; });
 
 			that.hexagons.transition().duration(200)
-				.attr('fill', function(d){ return that._colorScale(d.length); });
+				.attr('fill', function(d){ return that._colorScale(that.options.value(d)); });
 
 			that.hexagons.enter().append('path').attr('class', 'hexbin-hexagon')
 				.attr('d', function(d){
-					return 'M' + d.x + ',' + d.y + that._hexLayout.hexagon(that._radiusScale(d.length));
+					return 'M' + d.x + ',' + d.y + that._hexLayout.hexagon(that._radiusScale(that.options.value(d)));
 				})
-				.attr('fill', function(d){ return that._colorScale(d.length); })
+				.attr('fill', function(d){ return that._colorScale(that.options.value(d)); })
 				.attr('opacity', 0.01)
 				.transition().duration(200)
 				.attr('opacity', that.options.opacity)

--- a/src/js/HexbinLayer.js
+++ b/src/js/HexbinLayer.js
@@ -2,8 +2,8 @@
 	"use strict";
 
   // L is defined by the Leaflet library, see git://github.com/Leaflet/Leaflet.git for documentation
-	L.HexbinLayer = L.Class.extend({
-		includes: [L.Mixin.Events],
+	L.HexbinLayer = L.Layer.extend({
+		includes: [L.Evented],
 
 		options : {
 			radius : 10,


### PR DESCRIPTION
Replaced L.Class with L.Layer as L.Class no longer works, and replaced L.Mixin.Events with L.Evented as Mixin.Events is deprecated.

Also fixed a bug where the number of points in a hexagon is used to determine its colour and radius instead of the value function defined in options.